### PR TITLE
ci: use texlive container instead of installing texlive

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    container: texlive/texlive:latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -33,12 +34,6 @@ jobs:
             printf '[ERROR]: Git tag (%s) wrong format\n' "$_tag"
             exit 1
           fi
-
-      - name: Install TeX Live
-        uses: teatimeguest/setup-texlive-action@v3
-        with:
-          packages: >-
-            scheme-full
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
I've had some issues with my thesis as it wouldn't build, furthermore, since it wouldn't build, it always took 40 minutes to build and fail. This should remove the longest build step and use a container with everything already installed instead.